### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/live-top10-memory-usage/configs.xml
+++ b/live-top10-memory-usage/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This widget lists hosts ordered by memory usage (percentage). It is possible to select the number of lines in the table or to select a subset of resources.</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, memory</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/live-top10-memory-usage/resources/logo1.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix