### PR TITLE
adapting widget live top10 memory usage to dark mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "config": {
     "secure-http": false,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
-    "squizlabs/php_codesniffer": "^3.6.2"
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "config": {
     "secure-http": false,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
-    "squizlabs/php_codesniffer": "^3.6"
+    "squizlabs/php_codesniffer": "^3.6.2"
   },
   "config": {
     "secure-http": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19b63598c5c583609b57b986d11de361",
+    "content-hash": "b85d690e264cb2b44b1337ecc19d9a95",
     "packages": [],
     "packages-dev": [
         {
@@ -1595,16 +1595,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -1647,7 +1647,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1842,5 +1842,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/live-top10-memory-usage/index.php
+++ b/live-top10-memory-usage/index.php
@@ -77,6 +77,11 @@ try {
     if ($autoRefresh < 5) {
         $autoRefresh = 30;
     }
+    $variablesThemeCSS = match ($centreon->user->theme) {
+        'light' => "Generic-theme",
+        'dark' => "Centreon-Dark",
+        default => throw new \Exception('Unknown user theme : ' . $centreon->user->theme),
+    };
 } catch (Exception $e) {
     echo $e->getMessage() . "<br/>";
     exit;
@@ -158,6 +163,7 @@ while ($row = $res->fetchRow()) {
     $numLine++;
 }
 
+$template->assign('theme', $variablesThemeCSS);
 $template->assign('preferences', $preferences);
 $template->assign('widgetId', $widgetId);
 $template->assign('preferences', $preferences);

--- a/live-top10-memory-usage/src/table_top10memory.ihtml
+++ b/live-top10-memory-usage/src/table_top10memory.ihtml
@@ -1,17 +1,9 @@
 <html>
 <head>
     <title>live-top10-memory-usage</title>
-    <link href="../../Themes/Centreon-2/style.css" type="text/css"/>
-    <link href="../../Themes/Centreon-2/Color/blue_css.php" rel="stylesheet" text="text/css"/>
-    {literal}
-    <style type="text/css">
-        .ListTable {font-size:11px;border-color: #BFD0E2;}
-    </style>
-    <style>
-        @import url('src/top10_memory.css');
-        @import url('../../Themes/Centreon-2/style.css');
-    </style>
-    {/literal}
+            <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
+            <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
+            <link href="../../Themes/{$theme}/variables.css"  rel="stylesheet" type="text/css"/>
 </head>
 <body>
     {if $preferences.service_description != '' && $preferences.metric_name != '' && $preferences.nb_lin != ''}


### PR DESCRIPTION
# Pull Request Template

## Description

applying the new styles to the widget and dark mode.

**Fixes** #MON-12616

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
